### PR TITLE
Support adding Fedora non-Rawhide repositories to Mock's "config_opts['yum.conf']" option

### DIFF
--- a/features/add_repository.feature
+++ b/features/add_repository.feature
@@ -16,6 +16,13 @@ Feature: Add repositories to config_opts['yum.conf']
   In order to test a project with various dependencies, I want to add
   repositories to the Mock's "config_opts['yum.conf']" option.
 
+  Scenario: Add Fedora 22
+    Given following options are configured as follows:
+       | Option            | Value |
+       | --add-non-rawhide | 22    |
+     When I execute this program
+     Then I should have the result that is produced if config_opts['yum.conf'] contains the Fedora 22 repository
+
   Scenario: Add Fedora Rawhide
     Given following options are configured as follows:
        | Option        |

--- a/features/environment.py
+++ b/features/environment.py
@@ -37,6 +37,9 @@ attributes:
     dnf-stack-ci.
 :attr:`!fedora_option` : :data:`types.UnicodeType` | :data:`None`
     A value of the target Fedora release version option.
+:attr:`!nonrawhide_option` : :class:`list[types.UnicodeType]`
+    The version of each Fedora non-Rawhide repository that should be
+    added to the Mock's "config_opts['yum.conf']" option.
 :attr:`!rawhide_option` : :class:`bool`
     ``True`` if the Fedora Rawhide repository should be added to the
     Mock's "config_opts['yum.conf']" option, ``False`` otherwise.
@@ -114,6 +117,7 @@ def before_feature(context, feature):  # pylint: disable=unused-argument
     context.workdn = dnfstackci.decode_path(tempfile.mkdtemp())
     context.arch_option = 'x86_64'
     context.fedora_option = None
+    context.nonrawhide_option = []
     context.rawhide_option = False
     context.def_option = []
     context.dest_option = context.workdn

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -73,6 +73,8 @@ def _configure_options(context):
             context.arch_option = row[1]
         elif row[0] == '--fedora' and len(row) == 2:
             context.fedora_option = row[1]
+        elif row[0] == '--add-non-rawhide' and len(row) == 2:
+            context.nonrawhide_option.append(row[1])
         elif row[0] == '--add-rawhide' and len(row) == 1:
             context.rawhide_option = True
         elif row[0] == '--define' and len(row) == 3:
@@ -118,6 +120,9 @@ def _build_tito_rpms(context):
         cmdline.insert(2, '--define')
     if context.rawhide_option:
         cmdline.insert(2, '--add-rawhide')
+    for version in reversed(context.nonrawhide_option):
+        cmdline.insert(2, version)
+        cmdline.insert(2, '--add-non-rawhide')
     if context.fedora_option is not None:
         cmdline.insert(2, context.fedora_option)
         cmdline.insert(2, '--fedora')
@@ -204,12 +209,14 @@ def _test_releasever(context):
 # FIXME: https://bitbucket.org/logilab/pylint/issue/535
 @behave.then(  # pylint: disable=no-member
     "I should have the result that is produced if config_opts['yum.conf'] "
-    'contains the Rawhide repository')
-def _test_repository(context):
+    'contains the {repository} repository')
+def _test_repository(context, repository):  # pylint: disable=unused-argument
     """Test whether the result is affected by a repo. in "yum.conf".
 
     :param context: the context as described in the environment file
     :type context: behave.runner.Context
+    :param repository: a name of the repository
+    :type repository: unicode
     :raises exceptions.ValueError: if the result cannot be obtained or
        if the test fails
 


### PR DESCRIPTION
Resolves #22